### PR TITLE
ci: Update workflows to run when needed

### DIFF
--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -7,8 +7,17 @@ on:
     paths:
       - '.github/workflows/action-integration.yml'
       - 'action.yml'
+      - 'Dockerfile'
+      - '.github/scripts/replace_inputs.sh'
+      - '**/*.py'
 
   pull_request_target:
+    paths:
+      - '.github/workflows/action-integration.yml'
+      - 'action.yml'
+      - 'Dockerfile'
+      - '**/*.py'
+
 jobs:
   action-integration-testing:
     name: Action Integration Testing

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,9 +5,13 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/python-ci.yml'
+      - 'action.yml'
       - '**/*.py'
   pull_request:
     paths:
+      - '.github/workflows/python-ci.yml'
+      - 'action.yml'
       - '**/*.py'
 
 jobs:


### PR DESCRIPTION
## Description
Only run workflows when underlying files that impact them change.

## Motivation and Context
Reduce cost and overhead/time of workflow runs.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects