### PR TITLE
ci: Fix triggers on test docker image

### DIFF
--- a/.github/workflows/test-docker-image.yml
+++ b/.github/workflows/test-docker-image.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - 'Dockerfile'
+      - pyproject.toml
       - '.github/scripts/replace_inputs.sh'
       - '**/*.py'
   pull_request:
     paths:
       - 'Dockerfile'
+      - pyproject.toml
       - '.github/scripts/replace_inputs.sh'
       - '**/*.py'
 


### PR DESCRIPTION
## Description
Docker image should be tested when the python libraries etc. are updated

## Motivation and Context
Docker image not being tested in all cases where it will change upon release.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects