### PR TITLE
fix: Enable files with private repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ coverage.xml
 __pycache__/
 .idea
 .vscode
+.env
+test.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,5 @@ COPY --from=builder /app/dist/repo-manager-static /repo-manager
 COPY --from=builder /app/tmp /tmp
 
 RUN git --version
+RUN git config --global user.name "Repo Manager Bot"
+RUN git config --global user.email "repo-mgr@bots.noreply.github.com"

--- a/repo_manager/gh/files.py
+++ b/repo_manager/gh/files.py
@@ -25,7 +25,7 @@ def __clone_repo__(repo: Repository, branch: str) -> Repo:
     if repo_dir.is_dir():
         raise FileExistsError(f"Directory {repo_dir} already exists")
     actions_toolkit.info(f"Cloning {repo.full_name} to {repo_dir}")
-    cloned_repo = Repo.clone_from(repo.clone_url.replace("https://",f"https://{inputs["token"]}@"), str(repo_dir))
+    cloned_repo = Repo.clone_from(repo.clone_url.replace("https://", f"https://{inputs["token"]}@"), str(repo_dir))
     cloned_repo.git.checkout(branch)
     return cloned_repo
 

--- a/repo_manager/gh/files.py
+++ b/repo_manager/gh/files.py
@@ -25,7 +25,7 @@ def __clone_repo__(repo: Repository, branch: str) -> Repo:
     if repo_dir.is_dir():
         raise FileExistsError(f"Directory {repo_dir} already exists")
     actions_toolkit.info(f"Cloning {repo.full_name} to {repo_dir}")
-    cloned_repo = Repo.clone_from(repo.clone_url.replace("https://", f"https://{inputs["token"]}@"), str(repo_dir))
+    cloned_repo = Repo.clone_from(repo.clone_url.replace("https://", f"https://{inputs['token']}@"), str(repo_dir))
     cloned_repo.git.checkout(branch)
     return cloned_repo
 

--- a/repo_manager/gh/files.py
+++ b/repo_manager/gh/files.py
@@ -19,11 +19,13 @@ commitCleanup: Commit = None
 
 def __clone_repo__(repo: Repository, branch: str) -> Repo:
     """Clone a repository to the local filesystem"""
+
     inputs = get_inputs()
     repo_dir = Path(inputs["workspace_path"]) / repo.name
     if repo_dir.is_dir():
         raise FileExistsError(f"Directory {repo_dir} already exists")
-    cloned_repo = Repo.clone_from(repo.clone_url, str(repo_dir))
+    actions_toolkit.info(f"Cloning {repo.full_name} to {repo_dir}")
+    cloned_repo = Repo.clone_from(repo.clone_url.replace("https://",f"https://{inputs["token"]}@"), str(repo_dir))
     cloned_repo.git.checkout(branch)
     return cloned_repo
 
@@ -59,13 +61,14 @@ def check_files(repo: Repository, files: list[FileConfig]) -> tuple[bool, dict[s
         # prior method used source if move was true, dest if not
         if not file_config.exists:
             fileToDelete = oldPath if file_config.move else newPath
+            fileToDeleteRelativePath = fileToDelete.relative_to(repo_dir.working_tree_dir)
             if fileToDelete.exists():
                 os.remove(fileToDelete)
-                extra.add(str(fileToDelete))
-                actions_toolkit.info(f"Deleted {str(fileToDelete.relative_to(repo_dir.working_tree_dir))}")
+                extra.add(str(fileToDeleteRelativePath))
+                actions_toolkit.info(f"Deleted {str(fileToDelete)}")
             else:
                 actions_toolkit.warning(
-                    f"{str(fileToDelete)} does not exist in {target_branch} branch."
+                    f"{str(fileToDeleteRelativePath)} does not exist in {target_branch} branch."
                     + "Because this is a delete, not failing run"
                 )
         else:
@@ -84,10 +87,10 @@ def check_files(repo: Repository, files: list[FileConfig]) -> tuple[bool, dict[s
                 else:
                     os.rename(oldPath, newPath)
                     moved += str(file_config.src_file)
-                    actions_toolkit.info(f"Moved {str(file_config.src_file)} to {str(file_config.dest_file)}")
+                    actions_toolkit.info(f"Moved {str(oldPath)} to {str(newPath)}")
             elif file_config.remote_src:
                 shutil.copyfile(oldPath, newPath)
-                actions_toolkit.info("Copied {str(file_config.src_file)} to {str(file_config.dest_file)}")
+                actions_toolkit.info(f"Copied {str(oldPath)} to {str(newPath)}")
 
     # we commit these changes so that deleted files and renamed files are accounted for
     global commitCleanup
@@ -114,7 +117,7 @@ def check_files(repo: Repository, files: list[FileConfig]) -> tuple[bool, dict[s
             if newPath.exists():
                 os.remove(newPath)  # Delete the file
             shutil.copyfile(srcPath, destPath)
-            actions_toolkit.info(f"Copied {str(file_config.src_file)} to {str(file_config.dest_file)}")
+            actions_toolkit.info(f"Copied {str(srcPath)} to {str(destPath)}")
 
     # we commit the file updates (e.g. content changes)
     global commitChanges


### PR DESCRIPTION
## Description
Enable:
- Cloning of private repos
- Pushing of the changes to the remote repo

## Motivation and Context
Switching from pygithub to gitpython for managing files in repo  broke the ability to send files up to the cloud.  This rectifies that.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects