### PR TITLE
fix: Tabulate needed for better markdown

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1507,6 +1507,20 @@ files = [
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
+name = "tabulate"
+version = "0.9.0"
+description = "Pretty-print tabular data"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
+    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
+]
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
 name = "tokenize-rt"
 version = "5.2.0"
 description = "A wrapper around the stdlib `tokenize` which roundtrips."
@@ -1658,4 +1672,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "797b152c4ee3f3b6131e46b1addcd54e6fe8b07c8f6c09a158349669d807f66f"
+content-hash = "67e36230f375f9a0529e262e9ac7ec725db64c8dff841cc136c9e3d6d629f6c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pyyaml = "^6.0"
 pydantic-extra-types = "^2.7.0"
 gitpython = "^3.1.43"
 pandas = "^2.2.2"
+tabulate = "^0.9.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Description
Better markdown in summaries and PRs

## Motivation and Context
Tabulate library lets us make tables with pandas more easily.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects