### PR TITLE
fix: Pandas uses hidden imports...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,10 @@ RUN poetry build
 RUN pip install dist/gha_repo_manager*.whl
 
 # pyinstaller package the app
-RUN python -OO -m PyInstaller -F repo_manager/main.py --name repo-manager --hidden-import _cffi_backend
+# https://docs.python.org/3/using/cmdline.html#interface-options
+# OO flag is for optimization (first O omit asserts and debug statements, second omits docstrings)
+# F flag is for one file, hidden-import is for cffi
+RUN python -OO -m PyInstaller -F repo_manager/main.py --name repo-manager --hidden-import _cffi_backend --hidden-import tabulate
 # static link the repo-manager binary
 RUN cd ./dist && \
     staticx -l $(ldconfig -p| grep libgcc_s.so.1 | awk -F "=>" '{print $2}' | tr -d " ") --strip repo-manager repo-manager-static && \

--- a/repo_manager/gh/files.py
+++ b/repo_manager/gh/files.py
@@ -194,10 +194,10 @@ def update_files(
         body = "# File updates:\n"
         if diffs.get("extra", None) is not None:
             body += "## Deleted:"
-            body += "\n".join(["- " + item for item in diffs["extra"]])
+            body += "\n".join(["- " + item for item in diffs["extra"] + "\n"])
         if diffs.get("missing", None) is not None:
             body += "## Created:\n"
-            body += "\n -".join(["- " + item for item in diffs["missing"]])
+            body += "\n -".join(["- " + item for item in diffs["missing"] + "\n"])
         if diffs.get("diff", None) is not None:
             body += "## Updated:\n"
             body += pd.DataFrame(diffs["diff"]).to_markdown()


### PR DESCRIPTION
## Description
Tell PyInstaller to include tabulate as a hidden import...

## Motivation and Context
Apparently pandas is notorious for [hidden_imports](https://forum.freecodecamp.org/t/help-with-converting-py-file-into-exe/476866/6) -- tabulate is one of them; have to instruct pyinstaller to import it to the compiled one file exe.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects