### PR TITLE
fix: Bug comparing branch protections

### DIFF
--- a/repo_manager/gh/branch_protections.py
+++ b/repo_manager/gh/branch_protections.py
@@ -383,17 +383,25 @@ def check_repo_branch_protections(
                 "expected": config_bp.protection.enforce_admins,
                 "found": this_protection.enforce_admins,
             }
-        if config_bp.protection.require_linear_history is not None and config_bp.protection.require_linear_history != this_protection.required_linear_history:
+        if (
+            config_bp.protection.require_linear_history is not None
+            and config_bp.protection.require_linear_history != this_protection.required_linear_history
+        ):
             diffs["require_linear_history"] = {
                 "expected": config_bp.protection.require_linear_history,
                 "found": this_protection.required_linear_history,
             }
-        if config_bp.protection.allow_force_pushes is not None and config_bp.protection.allow_force_pushes != this_protection.allow_force_pushes:
+        if (
+            config_bp.protection.allow_force_pushes is not None
+            and config_bp.protection.allow_force_pushes != this_protection.allow_force_pushes
+        ):
             diffs["allow_force_pushes"] = {
                 "expected": config_bp.protection.allow_force_pushes,
                 "found": this_protection.allow_force_pushes,
             }
-        if config_bp.protection.allow_deletions is not None and config_bp.protection.allow_deletions != this_protection.allow_deletions:
+        if (config_bp.protection.allow_deletions is not None
+            and config_bp.protection.allow_deletions != this_protection.allow_deletions
+        ):
             diffs["allow_deletions"] = {
                 "expected": config_bp.protection.allow_deletions,
                 "found": this_protection.allow_deletions,
@@ -401,8 +409,7 @@ def check_repo_branch_protections(
         # block_creations missing? Not sure if it is supported by the pygithub library
         if (
             config_bp.protection.require_conversation_resolution is not None
-            and config_bp.protection.require_conversation_resolution
-            != this_protection.required_conversation_resolution
+            and config_bp.protection.require_conversation_resolution != this_protection.required_conversation_resolution
         ):
             diffs["require_conversation_resolution"] = {
                 "expected": config_bp.protection.require_conversation_resolution,

--- a/repo_manager/gh/branch_protections.py
+++ b/repo_manager/gh/branch_protections.py
@@ -399,7 +399,8 @@ def check_repo_branch_protections(
                 "expected": config_bp.protection.allow_force_pushes,
                 "found": this_protection.allow_force_pushes,
             }
-        if (config_bp.protection.allow_deletions is not None
+        if (
+            config_bp.protection.allow_deletions is not None
             and config_bp.protection.allow_deletions != this_protection.allow_deletions
         ):
             diffs["allow_deletions"] = {

--- a/repo_manager/gh/branch_protections.py
+++ b/repo_manager/gh/branch_protections.py
@@ -383,23 +383,17 @@ def check_repo_branch_protections(
                 "expected": config_bp.protection.enforce_admins,
                 "found": this_protection.enforce_admins,
             }
-        if config_bp.protection.require_linear_history is not None and config_bp.protection.require_linear_history != (
-            this_protection.required_linear_history or ""
-        ):
+        if config_bp.protection.require_linear_history is not None and config_bp.protection.require_linear_history != this_protection.required_linear_history:
             diffs["require_linear_history"] = {
                 "expected": config_bp.protection.require_linear_history,
                 "found": this_protection.required_linear_history,
             }
-        if config_bp.protection.allow_force_pushes is not None and config_bp.protection.allow_force_pushes != (
-            this_protection.allow_force_pushes or ""
-        ):
+        if config_bp.protection.allow_force_pushes is not None and config_bp.protection.allow_force_pushes != this_protection.allow_force_pushes:
             diffs["allow_force_pushes"] = {
                 "expected": config_bp.protection.allow_force_pushes,
                 "found": this_protection.allow_force_pushes,
             }
-        if config_bp.protection.allow_deletions is not None and config_bp.protection.allow_deletions != (
-            this_protection.allow_deletions or ""
-        ):
+        if config_bp.protection.allow_deletions is not None and config_bp.protection.allow_deletions != this_protection.allow_deletions:
             diffs["allow_deletions"] = {
                 "expected": config_bp.protection.allow_deletions,
                 "found": this_protection.allow_deletions,
@@ -408,7 +402,7 @@ def check_repo_branch_protections(
         if (
             config_bp.protection.require_conversation_resolution is not None
             and config_bp.protection.require_conversation_resolution
-            != (this_protection.required_conversation_resolution or "")
+            != this_protection.required_conversation_resolution
         ):
             diffs["require_conversation_resolution"] = {
                 "expected": config_bp.protection.require_conversation_resolution,

--- a/repo_manager/utils/markdown.py
+++ b/repo_manager/utils/markdown.py
@@ -43,6 +43,7 @@ COLUMN_VALUE_TO_NAME = {
 COLUMN_RENAME_MAP = {
     "settings": "Setting",
     "label": "Setting",
+    "ruleset": "Setting",
     "missing": "Expected",
     "extra": "Found",
     "renamed": "Change",
@@ -66,7 +67,7 @@ ACTION_TAKEN = {
 
 KEYS_TO_DATAFRAME = ["collaborators", "branch_policies", "secrets", "branch", "updated"]
 
-KEYS_TO_COMPARE_A2E = ["settings", "label"]
+KEYS_TO_COMPARE_A2E = ["settings", "label", "ruleset"]
 
 KEYS_TO_SKIP_A_LEVEL = ["environments", "labels", "branch_protections", "variables"]
 


### PR DESCRIPTION
## Description
Failing on certain repo updates

## Motivation and Context
ynced branch_protections
  File "repo_manager/main.py", line 128, in <module>
  File "repo_manager/main.py", line 119, in main
  File "repo_manager/utils/markdown.py", line 320, in generate
  File "repo_manager/utils/markdown.py", line 309, in __section_handler__
  File "repo_manager/utils/markdown.py", line 286, in __key_handler__
  File "repo_manager/utils/markdown.py", line 288, in __key_handler__
  File "repo_manager/utils/markdown.py", line 268, in __action_handler__
  File "repo_manager/utils/markdown.py", line 309, in __section_handler__
  File "repo_manager/utils/markdown.py", line 298, in __key_handler__
  File "repo_manager/utils/markdown.py", line 309, in __section_handler__
  File "repo_manager/utils/markdown.py", line 298, in __key_handler__
  File "repo_manager/utils/markdown.py", line 309, in __section_handler__
  File "repo_manager/utils/markdown.py", line [29](https://git.nylcloud.com/Actuarial-Services/.github/actions/runs/113860/job/245702#step:6:30)8, in __key_handler__
AttributeError: 'bool' object has no attribute 'items'
[8] Failed to execute script 'main' due to unhandled exception!

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects