### PR TITLE
fix: Throw a warning instead of an error if a branch does not exist

### DIFF
--- a/repo_manager/gh/branch_protections.py
+++ b/repo_manager/gh/branch_protections.py
@@ -295,9 +295,10 @@ def check_repo_branch_protections(
 
     for config_bp in config_branch_protections:
         repo_bp = repo_branches.get(config_bp.name, None)
+        # Unfortunatly, the GitHub REST API does not support getting branch protection for a branch that does not exist
         if repo_bp is None and config_bp.exists:
-            # This should maybe be a regex pattern?
-            raise RuntimeError(f"Branch {config_bp.name} does not exist in repo {repo.full_name}")
+            actions_toolkit.warning(f"Branch {config_bp.name} does not exist in repo {repo.full_name} - skipping")
+            continue
         if not repo_bp.protected and config_bp.exists:
             missing_protections.append(config_bp.name)
             continue


### PR DESCRIPTION
## Description
Throw a warning instead of an error when trying to add branch protection to a branch that does not exist.

## Motivation and Context
If a branch does not exist, because the GitHub API cannot do robust wild-card branches etc. it should throw a warning instead of an error.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects