### PR TITLE
fix: Error when repo is self and cannot identify owner from repo name

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -10,10 +10,6 @@ on:
       - 'README.md'
   pull_request:
     paths:
-      - '.github/workflows/generate-docs.yml'
-      - 'action.yml'
-      - poetry.lock
-      - 'README.md'
 
 jobs:
   docs:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,7 +9,6 @@ on:
       - poetry.lock
       - 'README.md'
   pull_request:
-    paths:
 
 jobs:
   docs:

--- a/repo_manager/utils/__init__.py
+++ b/repo_manager/utils/__init__.py
@@ -50,7 +50,9 @@ def __get_inputs__() -> dict:
         #         kwargs[input_name] = input_config.get("default", None)
         #         if kwargs[input_name] is None:
         #             actions_toolkit.set_failed(f"Error getting inputs. {input_name} is missing a default")
-    kwargs["owner"] = kwargs["repo"].split("/")[0] if kwargs["repo"] != "self" else os.environ.get("GITHUB_REPOSITORY_OWNER", None)
+    kwargs["owner"] = (
+        kwargs["repo"].split("/")[0] if kwargs["repo"] != "self" else os.environ.get("GITHUB_REPOSITORY_OWNER", None)
+    )
     return kwargs
 
 

--- a/repo_manager/utils/__init__.py
+++ b/repo_manager/utils/__init__.py
@@ -50,7 +50,7 @@ def __get_inputs__() -> dict:
         #         kwargs[input_name] = input_config.get("default", None)
         #         if kwargs[input_name] is None:
         #             actions_toolkit.set_failed(f"Error getting inputs. {input_name} is missing a default")
-    kwargs["owner"] = kwargs["repo"].split("/")[0] if kwargs["repo"] is not None else None
+    kwargs["owner"] = kwargs["repo"].split("/")[0] if kwargs["repo"] != "self" else os.environ.get("GITHUB_REPOSITORY_OWNER", None)
     return kwargs
 
 


### PR DESCRIPTION
## Description
Owner is usually the prefix of the repo name, but when repo name is self there is no `/` to split on.

## Motivation and Context
Address a bug when repo parm is set to `self`

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects