### PR TITLE
ci: Wait for other checks before dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,8 +11,35 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for all other checks to complete
+        run: |
+          while true; do
+            statuses=$(gh pr checks ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --json name,status,conclusion \
+              --jq '.[] | select(.name != "${{ github.job }}") | {name, status, conclusion}')
+
+            echo "$statuses"
+
+            if echo "$statuses" | grep -qE '"status": "(queued|in_progress)"'; then
+              echo "Checks still running, waiting 30s..."
+              sleep 30
+            else
+              break
+            fi
+          done
+
+          if echo "$statuses" | grep -qE '"conclusion": "(failure|cancelled|timed_out|action_required)"'; then
+            echo "One or more checks failed."
+            exit 1
+          fi
+
+          echo "All other checks passed."
+        env:
+          GH_TOKEN: ${{ github.token }}
       - uses: actions/checkout@v6.0.2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2.6.6
         with:
           target: minor
-          github-token: ${{ github.token }}  #${{ secrets.THIS_PAT }}
+          command: squash and merge
+          github-token: ${{ github.token }} #${{ secrets.THIS_PAT }}


### PR DESCRIPTION
Polls PR so that all workflows complete before the auto merge command may be issued...