### PR TITLE
chore: Update release-please to use an app

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,14 @@ jobs:
     if: github.repository_owner == 'actuarysailor'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4.1.3
         with:
-          token: ${{ github.token }}  #${{ secrets.THIS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           manifest-file: .github/.release-please-manifest.json


### PR DESCRIPTION
Apparently the GITHUB_TOKEN cannot fire workflows defined to run when events occur...