### PR TITLE
chore: Branch Protection exists - false flag false diff

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -145,10 +145,6 @@ labels:
     description: Used by release-please to indicate a release is pending
     color: EDEDED
 
-branch_protections:
-  - name: main
-    exists: false   # Removed — replaced by rulesets below
-
 rulesets:
   - name: Protect main
     target: branch


### PR DESCRIPTION
Removed obsolete branch protection for 'main' and replaced it with rulesets.